### PR TITLE
Improve translation quality; show progress bar when loading content

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "com.example.lexis"
@@ -34,6 +35,11 @@ android {
     packagingOptions {
         exclude 'project.properties'
         exclude 'META-INF/INDEX.LIST'
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-parseviewer.js'
+        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.css'
+        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.html'
+        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.js'
     }
 }
 
@@ -64,6 +70,7 @@ dependencies {
     // Google NLP API for entity recognition
     implementation platform('com.google.cloud:libraries-bom:20.9.0')
     implementation 'com.google.cloud:google-cloud-language'
+    implementation 'io.grpc:grpc-okhttp:0.9.0'
 
     // Parceler for passing objects
     implementation 'org.parceler:parceler-api:1.1.12'
@@ -83,7 +90,4 @@ dependencies {
 
     // Coordinator layout for collapsing search bar
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-
-    // OpenNLP for named entity recognition
-    implementation 'org.apache.opennlp:opennlp-tools:1.6.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     }
     annotationProcessor 'com.google.cloud:google-cloud-translate:1.12.0'
 
+    // Google NLP API for entity recognition
+    implementation platform('com.google.cloud:libraries-bom:20.9.0')
+    implementation 'com.google.cloud:google-cloud-language'
+
     // Parceler for passing objects
     implementation 'org.parceler:parceler-api:1.1.12'
     annotationProcessor 'org.parceler:parceler:1.1.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,10 +36,6 @@ android {
         exclude 'project.properties'
         exclude 'META-INF/INDEX.LIST'
         exclude 'META-INF/DEPENDENCIES'
-        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-parseviewer.js'
-        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.css'
-        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.html'
-        exclude 'edu/stanford/nlp/pipeline/demo/corenlp-brat.js'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,5 +78,8 @@ dependencies {
     implementation 'com.yuyakaido.android:card-stack-view:2.3.4'
 
     // Coordinator layout for collapsing search bar
-    implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+
+    // OpenNLP for named entity recognition
+    implementation 'org.apache.opennlp:opennlp-tools:1.6.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Lexis">
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
         <activity android:name=".activities.MainActivity"></activity>
         <activity android:name=".activities.SignupActivity" />
         <activity android:name=".activities.LoginActivity">

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 
 import com.example.lexis.R;
@@ -13,16 +12,8 @@ import com.example.lexis.databinding.ActivityMainBinding;
 import com.example.lexis.fragments.FeedFragment;
 import com.example.lexis.fragments.PracticeFragment;
 import com.example.lexis.fragments.ProfileFragment;
-import com.example.lexis.utilities.Const;
 import com.example.lexis.utilities.TranslateUtils;
 import com.parse.ParseUser;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-
-import opennlp.tools.namefind.NameFinderME;
-import opennlp.tools.namefind.TokenNameFinderModel;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -35,47 +26,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         TranslateUtils.getTranslateService(this);
-        TranslateUtils.getNLPService()
-        ;
-        // get named-entity recognition model in background thread
-        new Thread(() -> {
-            try {
-                File filePerson = new File(getFilesDir(), Const.personModelFile);
-                if (!filePerson.exists()) {
-                    Log.i("MainActivity", "creating personModel.txt!");
-                    TranslateUtils.getPersonModel(MainActivity.this);
-                } else {
-                    Log.i("MainActivity", "personModel.txt exists!");
-                    FileInputStream isPerson = openFileInput(Const.personModelFile);
-                    TokenNameFinderModel personModel = new TokenNameFinderModel(isPerson);
-                    TranslateUtils.setPersonFinder(new NameFinderME(personModel));
-                }
-
-                File fileLocation = new File(getFilesDir(), Const.locationModelFile);
-                if (!fileLocation.exists()) {
-                    Log.i("MainActivity", "creating locationModel.txt!");
-                    TranslateUtils.getLocationModel(MainActivity.this);
-                } else {
-                    Log.i("MainActivity", "locationModel.txt exists!");
-                    FileInputStream isLocation = openFileInput(Const.locationModelFile);
-                    TokenNameFinderModel locationModel = new TokenNameFinderModel(isLocation);
-                    TranslateUtils.setLocationFinder(new NameFinderME(locationModel));
-                }
-
-                File fileOrganization = new File(getFilesDir(), Const.organizationModelFile);
-                if (!fileOrganization.exists()) {
-                    Log.i("MainActivity", "creating organizationModel.txt!");
-                    TranslateUtils.getOrganizationModel(MainActivity.this);
-                } else {
-                    Log.i("MainActivity", "organizationModel.txt exists!");
-                    FileInputStream isOrganization = openFileInput(Const.organizationModelFile);
-                    TokenNameFinderModel organizationModel = new TokenNameFinderModel(isOrganization);
-                    TranslateUtils.setOrganizationFinder(new NameFinderME(organizationModel));
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }).start();
+        TranslateUtils.getNLPService(this);
 
         // set up tab navigation
         binding.bottomNavigation.setOnNavigationItemSelectedListener(item -> {

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -35,6 +35,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         TranslateUtils.getTranslateService(this);
+        TranslateUtils.getNLPService()
+        ;
         // get named-entity recognition model in background thread
         new Thread(() -> {
             try {

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -15,6 +15,8 @@ import com.example.lexis.fragments.ProfileFragment;
 import com.example.lexis.utilities.TranslateUtils;
 import com.parse.ParseUser;
 
+import java.io.IOException;
+
 public class MainActivity extends AppCompatActivity {
 
     ActivityMainBinding binding;
@@ -26,6 +28,14 @@ public class MainActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         TranslateUtils.getTranslateService(this);
+        // get named-entity recognition model in background thread
+        new Thread(() -> {
+            try {
+                TranslateUtils.getNERModel(MainActivity.this);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
 
         // set up tab navigation
         binding.bottomNavigation.setOnNavigationItemSelectedListener(item -> {

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -15,7 +15,13 @@ import com.example.lexis.fragments.ProfileFragment;
 import com.example.lexis.utilities.TranslateUtils;
 import com.parse.ParseUser;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+
+import opennlp.tools.namefind.NameFinderME;
+import opennlp.tools.namefind.TokenNameFinderModel;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -31,10 +37,42 @@ public class MainActivity extends AppCompatActivity {
         // get named-entity recognition model in background thread
         new Thread(() -> {
             try {
-                TranslateUtils.getPersonModel(MainActivity.this);
-                TranslateUtils.getLocationModel(MainActivity.this);
-                TranslateUtils.getOrganizationModel(MainActivity.this);
-            } catch (IOException e) {
+                /*SharedPreferences prefs = getSharedPreferences("nlp_models", Context.MODE_PRIVATE);
+                Gson gson = new Gson();
+                String jsonPersonFinder = prefs.getString("personFinder", "");
+                String jsonLocationFinder = prefs.getString("locationFinder", "");
+                String jsonOrganizationFinder = prefs.getString("organizationFinder", "");*/
+
+                File filePerson = new File("personModel.txt");
+                if (!filePerson.exists()) {
+                    TranslateUtils.getPersonModel(MainActivity.this);
+                } else {
+                    FileInputStream isPerson = new FileInputStream(filePerson);
+                    ObjectInputStream ois = new ObjectInputStream(isPerson);
+                    TokenNameFinderModel personModel = (TokenNameFinderModel) ois.readObject();
+                    TranslateUtils.setPersonFinder(new NameFinderME(personModel));
+                }
+
+                File fileLocation = new File("locationModel.txt");
+                if (!fileLocation.exists()) {
+                    TranslateUtils.getLocationModel(MainActivity.this);
+                } else {
+                    FileInputStream isLocation = new FileInputStream(fileLocation);
+                    ObjectInputStream ois = new ObjectInputStream(isLocation);
+                    TokenNameFinderModel locationModel = (TokenNameFinderModel) ois.readObject();
+                    TranslateUtils.setLocationFinder(new NameFinderME(locationModel));
+                }
+
+                File fileOrganization = new File("organizationModel.txt");
+                if (!fileOrganization.exists()) {
+                    TranslateUtils.getOrganizationModel(MainActivity.this);
+                } else {
+                    FileInputStream isOrganization = new FileInputStream(fileOrganization);
+                    ObjectInputStream ois = new ObjectInputStream(isOrganization);
+                    TokenNameFinderModel organizationModel = (TokenNameFinderModel) ois.readObject();
+                    TranslateUtils.setOrganizationFinder(new NameFinderME(organizationModel));
+                }
+            } catch (IOException | ClassNotFoundException e) {
                 e.printStackTrace();
             }
         }).start();

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 
 import com.example.lexis.R;
@@ -12,13 +13,13 @@ import com.example.lexis.databinding.ActivityMainBinding;
 import com.example.lexis.fragments.FeedFragment;
 import com.example.lexis.fragments.PracticeFragment;
 import com.example.lexis.fragments.ProfileFragment;
+import com.example.lexis.utilities.Const;
 import com.example.lexis.utilities.TranslateUtils;
 import com.parse.ParseUser;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 
 import opennlp.tools.namefind.NameFinderME;
 import opennlp.tools.namefind.TokenNameFinderModel;
@@ -37,42 +38,39 @@ public class MainActivity extends AppCompatActivity {
         // get named-entity recognition model in background thread
         new Thread(() -> {
             try {
-                /*SharedPreferences prefs = getSharedPreferences("nlp_models", Context.MODE_PRIVATE);
-                Gson gson = new Gson();
-                String jsonPersonFinder = prefs.getString("personFinder", "");
-                String jsonLocationFinder = prefs.getString("locationFinder", "");
-                String jsonOrganizationFinder = prefs.getString("organizationFinder", "");*/
-
-                File filePerson = new File("personModel.txt");
+                File filePerson = new File(getFilesDir(), Const.personModelFile);
                 if (!filePerson.exists()) {
+                    Log.i("MainActivity", "creating personModel.txt!");
                     TranslateUtils.getPersonModel(MainActivity.this);
                 } else {
-                    FileInputStream isPerson = new FileInputStream(filePerson);
-                    ObjectInputStream ois = new ObjectInputStream(isPerson);
-                    TokenNameFinderModel personModel = (TokenNameFinderModel) ois.readObject();
+                    Log.i("MainActivity", "personModel.txt exists!");
+                    FileInputStream isPerson = openFileInput(Const.personModelFile);
+                    TokenNameFinderModel personModel = new TokenNameFinderModel(isPerson);
                     TranslateUtils.setPersonFinder(new NameFinderME(personModel));
                 }
 
-                File fileLocation = new File("locationModel.txt");
+                File fileLocation = new File(getFilesDir(), Const.locationModelFile);
                 if (!fileLocation.exists()) {
+                    Log.i("MainActivity", "creating locationModel.txt!");
                     TranslateUtils.getLocationModel(MainActivity.this);
                 } else {
-                    FileInputStream isLocation = new FileInputStream(fileLocation);
-                    ObjectInputStream ois = new ObjectInputStream(isLocation);
-                    TokenNameFinderModel locationModel = (TokenNameFinderModel) ois.readObject();
+                    Log.i("MainActivity", "locationModel.txt exists!");
+                    FileInputStream isLocation = openFileInput(Const.locationModelFile);
+                    TokenNameFinderModel locationModel = new TokenNameFinderModel(isLocation);
                     TranslateUtils.setLocationFinder(new NameFinderME(locationModel));
                 }
 
-                File fileOrganization = new File("organizationModel.txt");
+                File fileOrganization = new File(getFilesDir(), Const.organizationModelFile);
                 if (!fileOrganization.exists()) {
+                    Log.i("MainActivity", "creating organizationModel.txt!");
                     TranslateUtils.getOrganizationModel(MainActivity.this);
                 } else {
-                    FileInputStream isOrganization = new FileInputStream(fileOrganization);
-                    ObjectInputStream ois = new ObjectInputStream(isOrganization);
-                    TokenNameFinderModel organizationModel = (TokenNameFinderModel) ois.readObject();
+                    Log.i("MainActivity", "organizationModel.txt exists!");
+                    FileInputStream isOrganization = openFileInput(Const.organizationModelFile);
+                    TokenNameFinderModel organizationModel = new TokenNameFinderModel(isOrganization);
                     TranslateUtils.setOrganizationFinder(new NameFinderME(organizationModel));
                 }
-            } catch (IOException | ClassNotFoundException e) {
+            } catch (IOException e) {
                 e.printStackTrace();
             }
         }).start();

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -31,7 +31,9 @@ public class MainActivity extends AppCompatActivity {
         // get named-entity recognition model in background thread
         new Thread(() -> {
             try {
-                TranslateUtils.getNERModel(MainActivity.this);
+                TranslateUtils.getPersonModel(MainActivity.this);
+                TranslateUtils.getLocationModel(MainActivity.this);
+                TranslateUtils.getOrganizationModel(MainActivity.this);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/com/example/lexis/adapters/ArticlesAdapter.java
+++ b/app/src/main/java/com/example/lexis/adapters/ArticlesAdapter.java
@@ -87,6 +87,7 @@ public class ArticlesAdapter extends RecyclerView.Adapter<ArticlesAdapter.Articl
             task.execute(position);
         }
 
+        // TODO: AsyncTask is deprecated so I am unsure if I should be using something else instead
         class TranslateTask extends AsyncTask<Integer, Void, Integer> {
             @Override
             protected Integer doInBackground(Integer... integers) {

--- a/app/src/main/java/com/example/lexis/fragments/ArticleFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/ArticleFragment.java
@@ -58,24 +58,10 @@ public class ArticleFragment extends Fragment {
         if (getArguments() != null) {
             article = Parcels.unwrap(getArguments().getParcelable("article"));
 
-            SpannableStringBuilder styledContent = translateArticle();
+            SpannableStringBuilder styledContent = styleTranslatedWords(article);
             displayArticle(styledContent);
             setUpToolbar();
         }
-    }
-
-    /*
-    Translate the article if necessary and return the styled article.
-    */
-    private SpannableStringBuilder translateArticle() {
-        // only translate words if we haven't previously done so or if the user has changed their
-        // target language since the article's translation
-        String currentTargetLanguage = Utils.getCurrentTargetLanguage();
-        boolean isCorrectLanguage = article.getLanguage().equals(currentTargetLanguage);
-        if (article.getWordList() == null || !isCorrectLanguage) {
-            article.translateWordsOnInterval(3, 60);
-        }
-        return styleTranslatedWords(article);
     }
 
     /*

--- a/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
@@ -19,7 +19,6 @@ import com.example.lexis.R;
 import com.example.lexis.adapters.ArticlesAdapter;
 import com.example.lexis.databinding.FragmentFeedBinding;
 import com.example.lexis.models.Article;
-import com.example.lexis.utilities.Const;
 import com.example.lexis.utilities.Utils;
 
 import org.json.JSONArray;
@@ -60,6 +59,7 @@ public class FeedFragment extends Fragment {
         // only fetch articles if we haven't already fetched them
         if (articles == null) {
             articles = new ArrayList<>();
+            showProgressBar();
             fetchTopWikipediaArticles(Utils.getYesterday(), false);
         }
 
@@ -159,6 +159,11 @@ public class FeedFragment extends Fragment {
                     Article article = new Article(title, intro, "Wikipedia");
                     articles.add(article);
                     adapter.notifyItemInserted(articles.size() - 1);
+
+                    // we just added the last item, hide progress bar
+                    if (adapter.getItemCount() == 20) {
+                        hideProgressBar();
+                    }
                 } catch (JSONException e) {
                     Log.d(TAG, "JSON Exception", e);
                 }
@@ -169,5 +174,16 @@ public class FeedFragment extends Fragment {
                 Log.d(TAG, "onFailure to fetch Wikipedia article");
             }
         });
+    }
+
+    /*
+    Helper functions to hide and show progress bar.
+    */
+    public void showProgressBar() {
+        binding.progressBar.setVisibility(View.VISIBLE);
+    }
+
+    public void hideProgressBar() {
+        binding.progressBar.setVisibility(View.INVISIBLE);
     }
 }

--- a/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
@@ -63,7 +63,14 @@ public class FeedFragment extends Fragment {
             fetchTopWikipediaArticles(Utils.getYesterday(), false);
         }
 
-        // set up recyclerView
+        setUpRecyclerView();
+        Utils.setLanguageLogo(binding.toolbar.ivLogo);
+    }
+
+    /*
+    Set up the recyclerView for displaying articles.
+    */
+    private void setUpRecyclerView() {
         adapter = new ArticlesAdapter(this, articles);
         binding.rvArticles.setAdapter(adapter);
         binding.rvArticles.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -78,8 +85,6 @@ public class FeedFragment extends Fragment {
                 R.color.light_cyan,
                 R.color.orange_peel,
                 R.color.mellow_apricot);
-
-        Utils.setLanguageLogo(binding.toolbar.ivLogo);
     }
 
     /*

--- a/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
@@ -154,9 +154,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
 
             @Override
             public boolean onQueryTextChange(String newText) {
-                if (!newText.isEmpty()) {
-                    searchVocabulary(newText);
-                }
+                searchVocabulary(newText);
                 return false;
             }
         });
@@ -178,6 +176,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
     Fetch the user's vocabulary for the given languages.
     */
     private void queryVocabulary() {
+        showProgressBar();
         ParseQuery<Word> query = ParseQuery.getQuery(Word.class);
         query.include(Word.KEY_USER);
         query.whereEqualTo(Word.KEY_USER, ParseUser.getCurrentUser());
@@ -195,6 +194,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
                 Log.e(TAG, "Issue with getting vocabulary", e);
                 return;
             }
+            hideProgressBar();
             adapter.addAll(words);
             checkVocabularyEmpty(words);
         });
@@ -204,6 +204,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
     Search the user's vocabulary for the given query.
     */
     private void searchVocabulary(String searchQuery) {
+        showProgressBar();
         searchQuery = searchQuery.toLowerCase();
         ParseQuery<Word> targetWord = ParseQuery.getQuery(Word.class);
         targetWord.whereStartsWith(Word.KEY_TARGET_WORD_SEARCH, searchQuery);
@@ -233,6 +234,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
                 Log.e(TAG, "Issue with getting vocabulary", e);
                 return;
             }
+            hideProgressBar();
             adapter.clear();
             adapter.addAll(words);
             checkSearchEmpty(words);
@@ -317,5 +319,16 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
     @Override
     public void onFinishDialog(String targetLanguage, String targetWord, String englishWord) {
         Utils.addWordToDatabase(targetLanguage, targetWord, englishWord, binding.rvVocabulary);
+    }
+
+    /*
+    Helper functions to hide and show progress bar.
+    */
+    public void showProgressBar() {
+        binding.progressBar.setVisibility(View.VISIBLE);
+    }
+
+    public void hideProgressBar() {
+        binding.progressBar.setVisibility(View.INVISIBLE);
     }
 }

--- a/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
@@ -84,7 +84,7 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
     */
     private void setUpToolbar() {
         Utils.setLanguageLogo(binding.toolbar.ivLogo);
-        binding.toolbar.ibFilter.setOnClickListener((View.OnClickListener) v -> {
+        binding.toolbar.ibFilter.setOnClickListener(v -> {
             AppCompatActivity activity = (AppCompatActivity) getActivity();
             if (activity != null) {
                 FragmentManager fm = activity.getSupportFragmentManager();

--- a/app/src/main/java/com/example/lexis/models/Article.java
+++ b/app/src/main/java/com/example/lexis/models/Article.java
@@ -89,7 +89,7 @@ public class Article {
                     System.out.printf("Type: %s\n\n%n\n\n", mention.getType());
                 }
             }
-            
+
             /*
             // move to next word until we find an alphabetical word that is not a named entity
             while (!StringUtils.isAlpha(currentWord)) {

--- a/app/src/main/java/com/example/lexis/models/Article.java
+++ b/app/src/main/java/com/example/lexis/models/Article.java
@@ -83,7 +83,7 @@ public class Article {
         if (nameFinder != null) {
             Span[] nameSpans = nameFinder.find(words);
             for (Span s : nameSpans) {
-                Log.i(TAG, "Found name: " + s.toString() + "  " + words[s.getStart()]);
+                Log.i(TAG, "Found location: " + s.toString() + "  " + words[s.getStart()]);
             }
         }
 

--- a/app/src/main/java/com/example/lexis/models/Article.java
+++ b/app/src/main/java/com/example/lexis/models/Article.java
@@ -100,6 +100,11 @@ public class Article {
             */
             while (!StringUtils.isAlpha(currentWord) || (entity != null && (
                     type == EntityMention.Type.PROPER || type == EntityMention.Type.TYPE_UNKNOWN))) {
+                // we reached the last word and couldn't find anything appropriate to translate
+                if (currentIndex == words.length - 1) {
+                    break;
+                }
+
                 currentIndex++;
                 currentWord = words[currentIndex];
 
@@ -110,6 +115,12 @@ public class Article {
                         type = entity.getMentionsList().get(0).getType();
                     }
                 }
+            }
+
+            // we reached the last word and couldn't find anything appropriate to translate, so
+            // don't translate the last word and finish translating entirely
+            if (currentIndex == words.length - 1) {
+                break;
             }
 
             String stripped = Utils.stripPunctuation(currentWord, null);

--- a/app/src/main/java/com/example/lexis/models/Article.java
+++ b/app/src/main/java/com/example/lexis/models/Article.java
@@ -13,6 +13,9 @@ import org.parceler.Parcel;
 import java.util.ArrayList;
 import java.util.List;
 
+import opennlp.tools.namefind.NameFinderME;
+import opennlp.tools.util.Span;
+
 @Parcel
 public class Article {
 
@@ -75,9 +78,19 @@ public class Article {
         words = body.split("\\s+"); // split on whitespace
         String targetLanguage = Utils.getCurrentTargetLanguage();
         language = targetLanguage;
+
+        NameFinderME nameFinder = TranslateUtils.getNameFinder();
+        if (nameFinder != null) {
+            Span[] nameSpans = nameFinder.find(words);
+            for (Span s : nameSpans) {
+                Log.i(TAG, "Found name: " + s.toString() + "  " + words[s.getStart()]);
+            }
+        }
+
         for (int i = start; i < words.length; i += interval) {
             int currentIndex = i;
             String currentWord = words[currentIndex];
+            // move to next word until we find an alphabetical word
             while (!StringUtils.isAlpha(currentWord)) {
                 currentIndex++;
                 currentWord = words[currentIndex];
@@ -85,11 +98,11 @@ public class Article {
             String stripped = Utils.stripPunctuation(currentWord, null);
             try {
                 String translated = StringEscapeUtils.unescapeHtml4(TranslateUtils.translateSingleWord(stripped, targetLanguage));
-                translatedIndices.add(i);
-                originalWords.add(words[i]);
-                words[i] = translated;
+                translatedIndices.add(currentIndex);
+                originalWords.add(words[currentIndex]);
+                words[currentIndex] = translated;
             } catch (TranslateException e) {
-                Log.e(TAG, "Error translating word: " + words[i], e);
+                Log.e(TAG, "Error translating word: " + words[currentIndex], e);
             }
         }
     }

--- a/app/src/main/java/com/example/lexis/models/Article.java
+++ b/app/src/main/java/com/example/lexis/models/Article.java
@@ -6,6 +6,7 @@ import com.example.lexis.utilities.TranslateUtils;
 import com.example.lexis.utilities.Utils;
 import com.google.cloud.translate.TranslateException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.parceler.Parcel;
 
@@ -75,7 +76,12 @@ public class Article {
         String targetLanguage = Utils.getCurrentTargetLanguage();
         language = targetLanguage;
         for (int i = start; i < words.length; i += interval) {
-            String currentWord = words[i];
+            int currentIndex = i;
+            String currentWord = words[currentIndex];
+            while (!StringUtils.isAlpha(currentWord)) {
+                currentIndex++;
+                currentWord = words[currentIndex];
+            }
             String stripped = Utils.stripPunctuation(currentWord, null);
             try {
                 String translated = StringEscapeUtils.unescapeHtml4(TranslateUtils.translateSingleWord(stripped, targetLanguage));

--- a/app/src/main/java/com/example/lexis/utilities/Const.java
+++ b/app/src/main/java/com/example/lexis/utilities/Const.java
@@ -15,4 +15,8 @@ public class Const {
         put("de", R.drawable.logo_germany);
         put("tr", R.drawable.logo_turkey);
     }};
+
+    public static final String personModelFile = "personModel.txt";
+    public static final String locationModelFile = "locationModel.txt";
+    public static final String organizationModelFile = "organizationModel.txt";
 }

--- a/app/src/main/java/com/example/lexis/utilities/Const.java
+++ b/app/src/main/java/com/example/lexis/utilities/Const.java
@@ -15,8 +15,4 @@ public class Const {
         put("de", R.drawable.logo_germany);
         put("tr", R.drawable.logo_turkey);
     }};
-
-    public static final String personModelFile = "personModel.txt";
-    public static final String locationModelFile = "locationModel.txt";
-    public static final String organizationModelFile = "organizationModel.txt";
 }

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -1,6 +1,7 @@
 package com.example.lexis.utilities;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.StrictMode;
 
 import com.example.lexis.R;
@@ -9,7 +10,11 @@ import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateException;
 import com.google.cloud.translate.TranslateOptions;
 import com.google.cloud.translate.Translation;
+import com.google.gson.Gson;
 
+import java.io.BufferedOutputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -56,6 +61,7 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-person.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         personFinder = new NameFinderME(model);
+        saveModel(model, "personModel.txt");
     }
 
     /*
@@ -65,6 +71,7 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-location.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         locationFinder = new NameFinderME(model);
+        saveModel(model, "locationModel.txt");
     }
 
     /*
@@ -74,6 +81,38 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-organization.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         organizationFinder = new NameFinderME(model);
+        saveModel(model, "organizationModel.txt");
+    }
+
+    public static void saveModel(TokenNameFinderModel model, String filename) throws IOException {
+        BufferedOutputStream modelOut = new BufferedOutputStream(new FileOutputStream(filename));
+        model.serialize(modelOut);
+        modelOut.close();
+    }
+
+    /*
+    TODO: add comment here
+    */
+    private static void saveToPreferences(Context context, TokenNameFinderModel model, String key) {
+        SharedPreferences prefs = context.getSharedPreferences("nlp_models", Context.MODE_PRIVATE);
+        SharedPreferences.Editor prefsEditor = prefs.edit();
+        Gson gson = new Gson();
+        String json = gson.toJson(model);
+        prefsEditor.putString(key, json);
+        prefsEditor.commit();
+        prefsEditor.clear();
+    }
+
+    public static void setPersonFinder(NameFinderME personFinder) {
+        TranslateUtils.personFinder = personFinder;
+    }
+
+    public static void setOrganizationFinder(NameFinderME organizationFinder) {
+        TranslateUtils.organizationFinder = organizationFinder;
+    }
+
+    public static void setLocationFinder(NameFinderME locationFinder) {
+        TranslateUtils.locationFinder = locationFinder;
     }
 
     public static NameFinderME getPersonFinder() {

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -43,7 +43,7 @@ public class TranslateUtils {
     TODO: add comment here
     */
     public static void getNERModel(Context context) throws IOException {
-        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-person.bin");
+        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-location.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         nameFinder = new NameFinderME(model);
     }

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -13,8 +13,12 @@ import com.google.cloud.translate.Translation;
 import java.io.IOException;
 import java.io.InputStream;
 
+import opennlp.tools.namefind.NameFinderME;
+import opennlp.tools.namefind.TokenNameFinderModel;
+
 public class TranslateUtils {
     private static Translate translate;
+    private static NameFinderME nameFinder;
 
     /*
     Get the translation service using credentials JSON file for the API key.
@@ -33,6 +37,22 @@ public class TranslateUtils {
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }
+    }
+
+    /*
+    TODO: add comment here
+    */
+    public static void getNERModel(Context context) throws IOException {
+        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-person.bin");
+        TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
+        nameFinder = new NameFinderME(model);
+    }
+
+    /*
+    TODO: add comment here
+    */
+    public static NameFinderME getNameFinder() {
+        return nameFinder;
     }
 
     /*

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -1,8 +1,8 @@
 package com.example.lexis.utilities;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.StrictMode;
+import android.util.Log;
 
 import com.example.lexis.R;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -10,10 +10,7 @@ import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateException;
 import com.google.cloud.translate.TranslateOptions;
 import com.google.cloud.translate.Translation;
-import com.google.gson.Gson;
 
-import java.io.BufferedOutputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,7 +58,7 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-person.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         personFinder = new NameFinderME(model);
-        saveModel(model, "personModel.txt");
+        saveModel(context, model, Const.personModelFile);
     }
 
     /*
@@ -71,7 +68,7 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-location.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         locationFinder = new NameFinderME(model);
-        saveModel(model, "locationModel.txt");
+        saveModel(context, model, Const.locationModelFile);
     }
 
     /*
@@ -81,26 +78,18 @@ public class TranslateUtils {
         InputStream inputStreamNameFinder = context.getAssets().open("en-ner-organization.bin");
         TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
         organizationFinder = new NameFinderME(model);
-        saveModel(model, "organizationModel.txt");
+        saveModel(context, model, Const.organizationModelFile);
     }
 
-    public static void saveModel(TokenNameFinderModel model, String filename) throws IOException {
-        BufferedOutputStream modelOut = new BufferedOutputStream(new FileOutputStream(filename));
-        model.serialize(modelOut);
-        modelOut.close();
-    }
-
-    /*
-    TODO: add comment here
-    */
-    private static void saveToPreferences(Context context, TokenNameFinderModel model, String key) {
-        SharedPreferences prefs = context.getSharedPreferences("nlp_models", Context.MODE_PRIVATE);
-        SharedPreferences.Editor prefsEditor = prefs.edit();
-        Gson gson = new Gson();
-        String json = gson.toJson(model);
-        prefsEditor.putString(key, json);
-        prefsEditor.commit();
-        prefsEditor.clear();
+    public static void saveModel(Context context, TokenNameFinderModel model, String filename) {
+        try {
+            FileOutputStream fileOut = context.openFileOutput(filename, Context.MODE_PRIVATE);
+            model.serialize(fileOut);
+            fileOut.close();
+            Log.i("TranslateUtils", "saved to " + filename);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public static void setPersonFinder(NameFinderME personFinder) {

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -6,6 +6,11 @@ import android.util.Log;
 
 import com.example.lexis.R;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.language.v1.AnalyzeEntitiesRequest;
+import com.google.cloud.language.v1.AnalyzeEntitiesResponse;
+import com.google.cloud.language.v1.Document;
+import com.google.cloud.language.v1.EncodingType;
+import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateException;
 import com.google.cloud.translate.TranslateOptions;
@@ -20,6 +25,7 @@ import opennlp.tools.namefind.TokenNameFinderModel;
 
 public class TranslateUtils {
     private static Translate translate;
+    private static LanguageServiceClient language;
     private static NameFinderME personFinder;
     private static NameFinderME organizationFinder;
     private static NameFinderME locationFinder;
@@ -49,6 +55,28 @@ public class TranslateUtils {
     public static String translateSingleWord(String originalWord, String targetLanguage) throws TranslateException {
         Translation translation = translate.translate(originalWord, Translate.TranslateOption.targetLanguage(targetLanguage), Translate.TranslateOption.model("base"));
         return translation.getTranslatedText(); // TODO: potentially look into providing more context?
+    }
+
+    // TODO: add comment
+    public static void getNLPService() {
+        try (LanguageServiceClient languageClient = LanguageServiceClient.create()) {
+            language = languageClient;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // TODO: add comment
+    public static AnalyzeEntitiesResponse analyzeEntities(String text) {
+        Document doc = Document.newBuilder().setContent(text).setType(Document.Type.PLAIN_TEXT).build();
+        AnalyzeEntitiesRequest request =
+                AnalyzeEntitiesRequest.newBuilder()
+                        .setDocument(doc)
+                        .setEncodingType(EncodingType.UTF16)
+                        .build();
+
+        AnalyzeEntitiesResponse response = language.analyzeEntities(request);
+        return response;
     }
 
     /*

--- a/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
+++ b/app/src/main/java/com/example/lexis/utilities/TranslateUtils.java
@@ -18,7 +18,9 @@ import opennlp.tools.namefind.TokenNameFinderModel;
 
 public class TranslateUtils {
     private static Translate translate;
-    private static NameFinderME nameFinder;
+    private static NameFinderME personFinder;
+    private static NameFinderME organizationFinder;
+    private static NameFinderME locationFinder;
 
     /*
     Get the translation service using credentials JSON file for the API key.
@@ -40,26 +42,49 @@ public class TranslateUtils {
     }
 
     /*
-    TODO: add comment here
-    */
-    public static void getNERModel(Context context) throws IOException {
-        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-location.bin");
-        TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
-        nameFinder = new NameFinderME(model);
-    }
-
-    /*
-    TODO: add comment here
-    */
-    public static NameFinderME getNameFinder() {
-        return nameFinder;
-    }
-
-    /*
     Translate a single word given by originalWord into the target language.
     */
     public static String translateSingleWord(String originalWord, String targetLanguage) throws TranslateException {
         Translation translation = translate.translate(originalWord, Translate.TranslateOption.targetLanguage(targetLanguage), Translate.TranslateOption.model("base"));
         return translation.getTranslatedText(); // TODO: potentially look into providing more context?
+    }
+
+    /*
+    TODO: add comment here
+    */
+    public static void getPersonModel(Context context) throws IOException {
+        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-person.bin");
+        TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
+        personFinder = new NameFinderME(model);
+    }
+
+    /*
+    TODO: add comment here
+    */
+    public static void getLocationModel(Context context) throws IOException {
+        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-location.bin");
+        TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
+        locationFinder = new NameFinderME(model);
+    }
+
+    /*
+    TODO: add comment here
+    */
+    public static void getOrganizationModel(Context context) throws IOException {
+        InputStream inputStreamNameFinder = context.getAssets().open("en-ner-organization.bin");
+        TokenNameFinderModel model = new TokenNameFinderModel(inputStreamNameFinder);
+        organizationFinder = new NameFinderME(model);
+    }
+
+    public static NameFinderME getPersonFinder() {
+        return personFinder;
+    }
+
+    public static NameFinderME getOrganizationFinder() {
+        return organizationFinder;
+    }
+
+    public static NameFinderME getLocationFinder() {
+        return locationFinder;
     }
 }

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -26,4 +26,13 @@
             android:layout_alignParentStart="true" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:indeterminateTint="@color/light_gray"
+        android:visibility="invisible"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true" />
+
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_practice.xml
+++ b/app/src/main/res/layout/fragment_practice.xml
@@ -86,4 +86,13 @@
         app:borderWidth="0dp"
         app:elevation="10dp"/>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:indeterminateTint="@color/light_gray"
+        android:visibility="invisible"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true" />
+
 </RelativeLayout>


### PR DESCRIPTION
## Description
This PR improves the quality of translated words by doing the following:
* Only words that are fully alphabetical are candidates for translation (i.e. numbers are not translated)
* Uses the Google Cloud NLP API entity recognition functions to avoid translating person names, locations, and organization names
* An indeterminate progress bar is shown while content (feed, article, or vocabulary) is loading

## Walkthrough GIF
* Shows progress bars on feed, article, and vocabulary loading
* Before integrating Google Cloud NLP API, numbers like "25", "2020", or names like "Jude" would be translated (and they are not anymore)

![translation-progress-bar](https://user-images.githubusercontent.com/17547686/127712775-d03e3982-a757-4326-8b17-0aa42b515978.gif)
