### PR TITLE
General bug fixes + quality improvements

### DIFF
--- a/app/src/main/java/com/example/lexis/activities/LoginActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/LoginActivity.java
@@ -67,6 +67,9 @@ public class LoginActivity extends AppCompatActivity {
             case 201:
                 errorMessage = "Password cannot be empty!";
                 break;
+            case 205:
+                errorMessage = "User e-mail is not verified.";
+                break;
             default:
                 errorMessage = "Error with log in!";
                 break;

--- a/app/src/main/java/com/example/lexis/activities/LoginActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/LoginActivity.java
@@ -1,6 +1,7 @@
 package com.example.lexis.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
 
 import android.content.Intent;
 import android.graphics.drawable.AnimationDrawable;
@@ -9,10 +10,13 @@ import android.widget.Toast;
 
 import com.example.lexis.R;
 import com.example.lexis.databinding.ActivityLoginBinding;
+import com.example.lexis.fragments.ForgotPasswordDialogFragment;
+import com.example.lexis.fragments.WordSearchFragment;
+import com.example.lexis.fragments.WordSearchHelpDialogFragment;
 import com.parse.ParseException;
 import com.parse.ParseUser;
 
-public class LoginActivity extends AppCompatActivity {
+public class LoginActivity extends AppCompatActivity implements ForgotPasswordDialogFragment.ForgotPasswordDialogListener {
 
     ActivityLoginBinding binding;
 
@@ -26,6 +30,7 @@ public class LoginActivity extends AppCompatActivity {
             goMainActivity();
         }
 
+        binding.tvForgotPassword.setOnClickListener(v -> forgotPasswordClicked());
         binding.tvSignup.setOnClickListener(v -> goSignUpActivity());
         binding.btnLogin.setOnClickListener(v -> {
             String username = binding.etUsername.getText().toString();
@@ -49,6 +54,29 @@ public class LoginActivity extends AppCompatActivity {
                 return;
             }
             goMainActivity();
+        });
+    }
+
+    /*
+    Show the forgot password dialog fragment.
+    */
+    private void forgotPasswordClicked() {
+        FragmentManager fm = getSupportFragmentManager();
+        ForgotPasswordDialogFragment dialog = new ForgotPasswordDialogFragment();
+        dialog.show(fm, "fragment_forgot_password");
+    }
+
+    /*
+    Send a password reset e-mail to the provided address.
+    */
+    @Override
+    public void onFinishDialog(String email) {
+        ParseUser.requestPasswordResetInBackground(email, e -> {
+            if (e == null) {
+                Toast.makeText(this, "Password reset e-mail sent.", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, e.getMessage(), Toast.LENGTH_SHORT).show();
+            }
         });
     }
 

--- a/app/src/main/java/com/example/lexis/activities/MainActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/MainActivity.java
@@ -10,8 +10,11 @@ import android.view.MenuItem;
 import com.example.lexis.R;
 import com.example.lexis.databinding.ActivityMainBinding;
 import com.example.lexis.fragments.FeedFragment;
+import com.example.lexis.fragments.PracticeFlashcardFragment;
 import com.example.lexis.fragments.PracticeFragment;
 import com.example.lexis.fragments.ProfileFragment;
+import com.example.lexis.fragments.WordSearchFragment;
+import com.example.lexis.models.WordSearch;
 import com.example.lexis.utilities.TranslateUtils;
 import com.parse.ParseUser;
 
@@ -64,5 +67,18 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         return false; // need to return false so that control is passed down to fragments
+    }
+
+    @Override
+    public void onBackPressed() {
+        WordSearchFragment wordSearchFragment = (WordSearchFragment) getSupportFragmentManager().findFragmentByTag("WordSearchFragment");
+        PracticeFlashcardFragment flashcardFragment = (PracticeFlashcardFragment) getSupportFragmentManager().findFragmentByTag("FlashcardFragment");
+        if (wordSearchFragment != null && wordSearchFragment.isVisible()) {
+            wordSearchFragment.returnToPracticeTab();
+        } else if (flashcardFragment != null && flashcardFragment.isVisible()) {
+            flashcardFragment.returnToPracticeTab();
+        } else {
+            super.onBackPressed();
+        }
     }
 }

--- a/app/src/main/java/com/example/lexis/activities/SignupActivity.java
+++ b/app/src/main/java/com/example/lexis/activities/SignupActivity.java
@@ -86,7 +86,9 @@ public class SignupActivity extends AppCompatActivity {
                 showErrorMessage(e);
                 return;
             }
-            goMainActivity();
+            Toast.makeText(this, "Account created! Please verify your e-mail before logging in.", Toast.LENGTH_SHORT).show();
+            ParseUser.logOut();
+            goLoginActivity();
         });
     }
 
@@ -99,10 +101,10 @@ public class SignupActivity extends AppCompatActivity {
     }
 
     /*
-    Navigate to the main activity and finish current one so user doesn't return to login screen.
+    Navigate to the login activity.
     */
-    private void goMainActivity() {
-        Intent i = new Intent(this, MainActivity.class);
+    private void goLoginActivity() {
+        Intent i = new Intent(this, LoginActivity.class);
         startActivity(i);
         finish();
     }

--- a/app/src/main/java/com/example/lexis/adapters/ArticlesAdapter.java
+++ b/app/src/main/java/com/example/lexis/adapters/ArticlesAdapter.java
@@ -147,7 +147,7 @@ public class ArticlesAdapter extends RecyclerView.Adapter<ArticlesAdapter.Articl
                     if (activity == null) return;
 
                     final FragmentManager fragmentManager = activity.getSupportFragmentManager();
-                    final Fragment articleFragment = ArticleFragment.newInstance(articles.get(position));
+                    final Fragment articleFragment = ArticleFragment.newInstance(article);
 
                     fragmentManager.beginTransaction()
                             .replace(R.id.fragmentContainer, articleFragment)

--- a/app/src/main/java/com/example/lexis/adapters/VocabularyAdapter.java
+++ b/app/src/main/java/com/example/lexis/adapters/VocabularyAdapter.java
@@ -52,6 +52,7 @@ public class VocabularyAdapter extends RecyclerView.Adapter<VocabularyAdapter.Vo
     public void insertAt(int position, Word word) {
         vocabulary.add(position, word);
         notifyItemInserted(position);
+        fragment.checkVocabularyEmpty(vocabulary);
     }
 
     public void clear() {

--- a/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/FeedFragment.java
@@ -138,9 +138,6 @@ public class FeedFragment extends Fragment {
                     for (int i = 2; i < 22; i++) {
                         JSONObject jsonArticle = jsonArticles.getJSONObject(i);
                         String title = jsonArticle.getString("article");
-                        if (title.startsWith("Wikipedia:") || title.startsWith("Special:")) {
-                            continue; // skip special Wikipedia pages
-                        }
                         fetchWikipediaArticle(title, i);
                     }
                 } catch (JSONException e) {
@@ -176,21 +173,24 @@ public class FeedFragment extends Fragment {
             public void onSuccess(int statusCode, Headers headers, JSON json) {
                 JSONObject jsonObject = json.jsonObject;
                 try {
-                    JSONObject pages = jsonObject
-                            .getJSONObject("query")
-                            .getJSONObject("pages");
-                    JSONObject articleObject = pages.getJSONObject(pages.keys().next());
+                    // skip special Wikipedia pages
+                    if (!title.startsWith("Wikipedia:") && !title.startsWith("Special:")) {
+                        JSONObject pages = jsonObject
+                                .getJSONObject("query")
+                                .getJSONObject("pages");
+                        JSONObject articleObject = pages.getJSONObject(pages.keys().next());
 
-                    // extract information from JSON object and do text pre-processing
-                    String source = "Wikipedia";
-                    String url = articleObject.getString("fullurl");
-                    String title = articleObject.getString("title");
-                    String intro = articleObject.getString("extract");
-                    intro = intro.replace("\n", "\n\n");
+                        // extract information from JSON object and do text pre-processing
+                        String source = "Wikipedia";
+                        String url = articleObject.getString("fullurl");
+                        String title = articleObject.getString("title");
+                        String intro = articleObject.getString("extract");
+                        intro = intro.replace("\n", "\n\n");
 
-                    Article article = new Article(title, intro, source, url);
-                    articles.add(article);
-                    adapter.notifyItemInserted(articles.size() - 1);
+                        Article article = new Article(title, intro, source, url);
+                        articles.add(article);
+                        adapter.notifyItemInserted(articles.size() - 1);
+                    }
 
                     // finished adding articles
                     if (index == 21) {

--- a/app/src/main/java/com/example/lexis/fragments/ForgotPasswordDialogFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/ForgotPasswordDialogFragment.java
@@ -1,0 +1,72 @@
+package com.example.lexis.fragments;
+
+import android.app.Dialog;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.lexis.databinding.FragmentForgotPasswordBinding;
+
+import org.apache.commons.validator.routines.EmailValidator;
+
+import javax.annotation.Nullable;
+
+public class ForgotPasswordDialogFragment extends DialogFragment {
+    FragmentForgotPasswordBinding binding;
+
+    public ForgotPasswordDialogFragment() {}
+
+    /*
+    Interface for listener used to pass data back to parent fragment.
+    */
+    public interface ForgotPasswordDialogListener {
+        void onFinishDialog(String email);
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        binding = FragmentForgotPasswordBinding.inflate(inflater);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        // set up cancel & send buttons
+        binding.btnSend.setOnClickListener(v -> {
+            ForgotPasswordDialogListener listener = (ForgotPasswordDialogListener) getActivity();
+            if (listener != null) {
+                String email = binding.etEmail.getText().toString();
+                if (email.isEmpty()) {
+                    Toast.makeText(getActivity(), "E-mail cannot be empty!", Toast.LENGTH_SHORT).show();
+                    return;
+                } else if (!EmailValidator.getInstance().isValid(email)) {
+                    Toast.makeText(getActivity(), "E-mail is not valid!", Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                listener.onFinishDialog(email);
+                dismiss();
+            }
+        });
+        binding.btnCancel.setOnClickListener(v -> dismiss());
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        Dialog dialog = getDialog();
+        if (dialog != null) {
+            // set a transparent background for the dialog so that rounded corners are visible
+            dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+    }
+}

--- a/app/src/main/java/com/example/lexis/fragments/PracticeFlashcardFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeFlashcardFragment.java
@@ -176,7 +176,7 @@ public class PracticeFlashcardFragment extends Fragment implements CardStackList
     /*
     Exit the practice session and return to the vocabulary view.
     */
-    private void returnToPracticeTab() {
+    public void returnToPracticeTab() {
         AppCompatActivity activity = (AppCompatActivity) getActivity();
         if (activity != null) {
             activity.getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.lexis.R;
 import com.example.lexis.fragments.VocabularyFilterDialogFragment.Sort;
@@ -92,6 +93,22 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
         SwipeDeleteCallback callback = new SwipeDeleteCallback(adapter);
         ItemTouchHelper touchHelper = new ItemTouchHelper(callback);
         touchHelper.attachToRecyclerView(binding.rvVocabulary);
+
+        // hide practice button if on last item so that user can see star / flag
+        binding.rvVocabulary.addOnScrollListener(new RecyclerView.OnScrollListener(){
+            @Override
+            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+                LinearLayoutManager layoutManager = (LinearLayoutManager) binding.rvVocabulary.getLayoutManager();
+                if (layoutManager != null) {
+                    int position = layoutManager.findLastCompletelyVisibleItemPosition();
+                    if (position == binding.rvVocabulary.getAdapter().getItemCount() - 1) {
+                        binding.btnPractice.hide();
+                    } else {
+                        binding.btnPractice.show();
+                    }
+                }
+            }
+        });
     }
 
     /*

--- a/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeFragment.java
@@ -101,8 +101,12 @@ public class PracticeFragment extends Fragment implements VocabularyFilterDialog
                 LinearLayoutManager layoutManager = (LinearLayoutManager) binding.rvVocabulary.getLayoutManager();
                 if (layoutManager != null) {
                     int position = layoutManager.findLastCompletelyVisibleItemPosition();
-                    if (position == binding.rvVocabulary.getAdapter().getItemCount() - 1) {
-                        binding.btnPractice.hide();
+                    View lastVisibleView = layoutManager.findViewByPosition(position);
+                    int lastItemIndex = binding.rvVocabulary.getAdapter().getItemCount() - 1;
+                    if (position != -1 && position == lastItemIndex) {
+                        if (Utils.viewsOverlap(lastVisibleView, binding.btnPractice)) {
+                            binding.btnPractice.hide();
+                        }
                     } else {
                         binding.btnPractice.show();
                     }

--- a/app/src/main/java/com/example/lexis/fragments/PracticeIntroFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/PracticeIntroFragment.java
@@ -206,7 +206,7 @@ public class PracticeIntroFragment extends Fragment {
         if (activity != null) {
             FragmentManager fragmentManager = activity.getSupportFragmentManager();
             fragmentManager.beginTransaction()
-                    .replace(R.id.fragmentContainer, flashcardFragment)
+                    .replace(R.id.fragmentContainer, flashcardFragment, "FlashcardFragment")
                     .commit();
         }
     }
@@ -224,7 +224,7 @@ public class PracticeIntroFragment extends Fragment {
         if (activity != null) {
             FragmentManager fragmentManager = activity.getSupportFragmentManager();
             fragmentManager.beginTransaction()
-                    .replace(R.id.fragmentContainer, wordSearchFragment)
+                    .replace(R.id.fragmentContainer, wordSearchFragment, "WordSearchFragment")
                     .commit();
         }
     }

--- a/app/src/main/java/com/example/lexis/fragments/WordSearchFragment.java
+++ b/app/src/main/java/com/example/lexis/fragments/WordSearchFragment.java
@@ -215,7 +215,7 @@ public class WordSearchFragment extends Fragment implements WordSearchHelpDialog
     /*
     Exit the practice session and return to the vocabulary view.
     */
-    private void returnToPracticeTab() {
+    public void returnToPracticeTab() {
         AppCompatActivity activity = (AppCompatActivity) getActivity();
         if (activity != null) {
             activity.getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/com/example/lexis/utilities/Utils.java
+++ b/app/src/main/java/com/example/lexis/utilities/Utils.java
@@ -10,6 +10,7 @@ import android.text.Layout;
 import android.text.SpannableString;
 import android.text.style.ClickableSpan;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -453,5 +454,23 @@ public class Utils {
     */
     public static int getTranslationInterval(ParseUser user) {
         return user.getInt("frequencyInterval");
+    }
+
+    /*
+    Return true if two views overlap on the screen, false otherwise.
+    */
+    public static boolean viewsOverlap(View firstView, View secondView) {
+        int[] firstPosition = new int[2];
+        int[] secondPosition = new int[2];
+
+        firstView.getLocationOnScreen(firstPosition);
+        secondView.getLocationOnScreen(secondPosition);
+
+        // Rect constructor parameters: left, top, right, bottom
+        Rect rectFirstView = new Rect(firstPosition[0], firstPosition[1],
+                firstPosition[0] + firstView.getMeasuredWidth(), firstPosition[1] + firstView.getMeasuredHeight());
+        Rect rectSecondView = new Rect(secondPosition[0], secondPosition[1],
+                secondPosition[0] + secondView.getMeasuredWidth(), secondPosition[1] + secondView.getMeasuredHeight());
+        return rectFirstView.intersect(rectSecondView);
     }
 }

--- a/app/src/main/res/drawable/forgot_password_background_shape.xml
+++ b/app/src/main/res/drawable/forgot_password_background_shape.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/feed_background_shape"
+    android:insetTop="210dp"
+    android:insetBottom="160dp"
+    android:insetRight="5dp"
+    android:insetLeft="5dp" >
+</inset>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -73,6 +73,15 @@
             android:inputType="textPassword" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <TextView
+        android:id="@+id/tvForgotPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="50dp"
+        android:gravity="end"
+        android:layout_marginTop="10dp"
+        android:text="@string/forgot_password" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnLogin"
         android:layout_width="120dp"
@@ -80,6 +89,12 @@
         android:layout_marginTop="20dp"
         app:cornerRadius="10dp"
         android:text="@string/log_in_label" />
+
+    <View
+        android:layout_width="150dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="15dp"
+        android:background="@color/light_gray"/>
 
     <TextView
         android:id="@+id/tvSignup"

--- a/app/src/main/res/layout/fragment_forgot_password.xml
+++ b/app/src/main/res/layout/fragment_forgot_password.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/vocabulary_filter"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="145dp"
-    android:paddingBottom="135dp"
-    android:paddingLeft="5dp"
-    android:paddingRight="5dp"
-    android:background="@drawable/dialog_background_shape">
+    android:paddingTop="220dp"
+    android:paddingBottom="165dp"
+    android:paddingLeft="10dp"
+    android:paddingRight="10dp"
+    android:background="@drawable/forgot_password_background_shape">
 
     <TextView
         android:id="@+id/tvTitle"
@@ -22,35 +21,24 @@
         android:textColor="@color/black"
         android:textSize="22sp"
         android:textStyle="bold"
-        android:text="@string/add_new_word_to_vocabulary" />
+        android:text="@string/forgot_password_title" />
 
     <TextView
-        android:id="@+id/tvTargetLanguage"
+        android:id="@+id/tvInstructions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/tvTitle"
         android:layout_alignStart="@id/tvTitle"
+        android:layout_marginEnd="20dp"
         android:layout_marginTop="15dp"
         android:textSize="16sp"
-        android:text="@string/target_language" />
-
-    <Spinner
-        android:id="@+id/spinnerLanguage"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/tvTargetLanguage"
-        android:minHeight="50dp"
-        android:paddingHorizontal="10dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginHorizontal="20dp"
-        android:background="@drawable/spinner_background_shape"
-        android:entries="@array/languages_array" />
+        android:text="@string/reset_password_instructions" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/etLayoutEnglish"
+        android:id="@+id/etLayoutEmail"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/spinnerLanguage"
+        android:layout_below="@id/tvInstructions"
         app:boxCornerRadiusTopStart="10dp"
         app:boxCornerRadiusTopEnd="10dp"
         app:boxCornerRadiusBottomStart="10dp"
@@ -58,44 +46,22 @@
         app:boxStrokeWidthFocused="0dp"
         app:boxStrokeWidth="0dp">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/etEnglishWord"
+            android:id="@+id/etEmail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="15dp"
             android:ems="10"
-            android:inputType="text"
-            android:hint="English word" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/etLayoutTarget"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/etLayoutEnglish"
-        app:boxCornerRadiusTopStart="10dp"
-        app:boxCornerRadiusTopEnd="10dp"
-        app:boxCornerRadiusBottomStart="10dp"
-        app:boxCornerRadiusBottomEnd="10dp"
-        app:boxStrokeWidthFocused="0dp"
-        app:boxStrokeWidth="0dp">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/etTargetWord"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="30dp"
-            android:ems="10"
-            android:inputType="text"
-            tools:hint="French translation" />
+            android:inputType="textEmailAddress"
+            android:hint="e-mail" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button
         android:id="@+id/btnCancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="20dp"
+        android:layout_below="@id/etLayoutEmail"
+        android:layout_marginTop="10dp"
         android:layout_marginStart="20dp"
         android:padding="0dp"
         android:minWidth="0dp"
@@ -105,17 +71,17 @@
         android:text="Cancel" />
 
     <Button
-        android:id="@+id/btnUpdate"
+        android:id="@+id/btnSend"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
+        android:layout_below="@id/etLayoutEmail"
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="20dp"
-        android:layout_marginBottom="20dp"
+        android:layout_marginTop="10dp"
         android:padding="0dp"
         android:minWidth="0dp"
         android:textColor="@color/tiffany_blue"
         android:textSize="16sp"
         android:background="@android:color/transparent"
-        android:text="Add" />
+        android:text="Send" />
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="currently_learning_label">Currently learning</string>
     <string name="confirm_password_label">confirm password</string>
     <string name="change_password_label">change password</string>
-    <string name="empty_vocabulary_prompt">You haven\'t studied any words yet!\n \nTap on a highlighted word within an article to see its meaning and add it to your vocabulary.</string>
+    <string name="empty_vocabulary_prompt">You haven\'t studied any words yet!\n \nTap on a highlighted word within an article to see its meaning and add it to your vocabulary, or add a word manually by tapping the plus button.</string>
     <string name="answer_in_english_label">🇺🇸 English</string>
     <string name="practice_prompt">How would you like to practice today?</string>
     <string name="start_practice_button_label">Let\'s go!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,7 @@
     <string name="regular">Regular</string>
     <string name="rare">Rare</string>
     <string name="account_settings">Account settings</string>
+    <string name="forgot_password">Forgot password?</string>
+    <string name="forgot_password_title">Forgot password</string>
+    <string name="reset_password_instructions">Enter the e-mail associated with your account below and we\'ll send you a link to reset your password!</string>
 </resources>


### PR DESCRIPTION
## Description
This PR introduces several bug fixes and quality improvements.

### Feed tab
* Fixed bug where content appears to load forever if the last Wikipedia article is skipped
* Fixed bug where tapping on an article while loading can cause crash

### Practice tab
* Practice button no longer hides star / flag options for the last item in vocabulary
* Fixed bug where manually adding a new word to empty vocabulary does not make recycler view visible
* Tapping on the native back button in the practice tab is no longer buggy

### Sign-up / login
* Implemented e-mail verification and password reset

## Walkthrough GIFs
Password reset

![password-reset](https://user-images.githubusercontent.com/17547686/129089455-b923976c-7a70-4243-a8da-2497ae299f89.gif)

Hiding practice button when scrolling to the bottom

![hide-practice](https://user-images.githubusercontent.com/17547686/129089565-b672f22e-9446-486c-aed1-a96ce874e9cb.gif)

Manually adding new word to vocabulary

 ![empty-vocabulary](https://user-images.githubusercontent.com/17547686/129089696-74100a32-467f-43aa-9fc8-a47a83253764.gif)
